### PR TITLE
Added check for code changes in cut-release workflow

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -11,6 +11,25 @@ on:
         default: minor
 
 jobs:
+  verify-code-changes:
+    name: Verify code has changed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get touched files
+        id: get-touched-files
+        uses: ./.github/actions/touched-files
+        with:
+          pathspec: 'src/ pyproject.toml'
+
+      - name: Fail if code has not changed
+        if: ${{ ! steps.get-touched-files.outputs.touched }}
+        run: |
+          echo "ERROR: No code changes detected."
+          exit 1
+
   cut-release:
     permissions:
       contents: write

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -31,13 +31,12 @@ jobs:
           exit 1
 
   cut-release:
+    name: Cut ${{ github.event.inputs.release-type }} release
+    needs: verify-code-changes
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-
-    runs-on: ubuntu-latest
-
-    name: Cut ${{ github.event.inputs.release-type }} release
 
     outputs:
       rc_version: ${{ steps.cut-release-branch.outputs.rc_version }}
@@ -92,8 +91,8 @@ jobs:
     with:
       target-branch: release
       version: ${{ needs.cut-release.outputs.rc_version }}
-    secrets:
-      pypi-token: ${{ secrets.PYPI_TOKEN }}
     permissions:
       contents: write
       id-token: write
+    secrets:
+      pypi-token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This pull request adds a new job to the GitHub Actions workflow to verify that code changes have been made before proceeding with the release process.

New job to verify code changes:

* [`.github/workflows/cut-release.yaml`](diffhunk://#diff-1a5999bd97773ff0eafe4d9bda1990420aa72a00dc4cdbc9a69349c8cf67bda2R14-R34): Added a `verify-code-changes` job that checks out the code, identifies touched files, and fails the workflow if no code changes are detected.