### PR TITLE
Added short|full option to bump-version script

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 
-USAGE="Usage: $0 major|minor|patch VERSION"
+USAGE="Usage: $0 major|minor|patch VERSION [short|full=short]"
 
 # Evaluate arguments
 case $# in
-    2)
-        case $1 in
-            major|minor|patch)
-                SEGMENT=$1
+    3)
+        case $3 in
+            short)
+                FULL=false
+                ;;
+            full)
+                FULL=true
                 ;;
             *)
-                echo "ERROR: Invalid version segment: $1" >&2
-                echo $USAGE
-                exit 1
+                FULL=false
                 ;;
         esac
-        VERSION=$2
+        ;;
+    2)
+        FULL=false
         ;;
     *)
         echo $USAGE
@@ -23,7 +26,20 @@ case $# in
         ;;
 esac
 
+# Evaluate version segment
+case $1 in
+    major|minor|patch)
+        SEGMENT=$1
+        ;;
+    *)
+        echo "ERROR: Invalid version segment: $1" >&2
+        echo $USAGE
+        exit 1
+        ;;
+esac
+
 # Determine release cycle
+VERSION=$2
 case $VERSION in
     *a*)
         CYCLE="a"
@@ -85,7 +101,7 @@ case $SEGMENT in
         ;;
 esac
 
-if [ "$CYCLE" == "." ] && [ "$PATCH" -eq 0 ]; then
+if [ "$CYCLE" == "." ] && [ "$PATCH" -eq 0 ] && [ "$FULL" == false ]; then
     echo "v$MAJOR.$MINOR"
 else
     echo "v$MAJOR.$MINOR$CYCLE$PATCH"


### PR DESCRIPTION
This pull request includes enhancements to the `scripts/bump-version.sh` script to provide more flexibility in version output formatting. The changes introduce a new optional argument to specify whether a short or full version should be generated.

Enhancements to version output formatting:

* [`scripts/bump-version.sh`](diffhunk://#diff-3b95b9d4ed59d1bb3424d2ccd660cef1ab56873d654c1ee1e47babb65331b012L3-R42): Added a new optional argument `[short|full=short]` allowing users to specify whether the version output should include the implied ".0" patch version in its output.
* [`scripts/bump-version.sh`](diffhunk://#diff-3b95b9d4ed59d1bb3424d2ccd660cef1ab56873d654c1ee1e47babb65331b012L88-R104): Modified the version output logic to conditionally include the implied patch version based on the new `FULL` flag.