### PR TITLE
Fixed typo in create-tag step of tag-version job in publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -19,7 +19,6 @@ jobs:
     if: ${{ github.event.pull_request.merged == true }}
     permissions:
       contents: write
-      pull-requests: write
     outputs:
       version: ${{ steps.create-tag.outputs.version }}
     steps:
@@ -56,7 +55,7 @@ jobs:
         run: |
           git fetch --unshallow
           old_version=$(git describe --tags --abbrev=0)
-          new_version=$(scripts/bump-version.sh ${{ steps.determine-version-segment.outputs.segment }} $version)
+          new_version=$(scripts/bump-version.sh ${{ steps.determine-version-segment.outputs.segment }} $old_version)
           echo "Bumping $old_version to $new_version"
           git tag $new_version
           git push origin $new_version


### PR DESCRIPTION
This pull request includes changes to the `publish-release` GitHub Actions workflow to fix a version bumping issue and adjust permissions.

Changes to the GitHub Actions workflow:

* [`.github/workflows/publish-release.yaml`](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7L22): Removed the `pull-requests: write` permission from the `permissions` section.
* [`.github/workflows/publish-release.yaml`](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7L59-R58): Modified the `new_version` variable assignment to use `old_version` instead of `version` in the `bump-version.sh` script.