### PR TITLE
Added code checkout steps to build-release and publish-release jobs in publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -66,6 +66,7 @@ jobs:
     needs: tag-version
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build-release
         with:
           version: ${{ needs.tag-version.outputs.version }}
@@ -77,6 +78,7 @@ jobs:
       - build-release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/publish-github-release
         with:
           version: ${{ needs.tag-version.outputs.version }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/publish-release.yaml` file to ensure the repository is correctly checked out before running subsequent actions.

Workflow improvements:

* [`.github/workflows/publish-release.yaml`](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7R69): Added `actions/checkout@v4` step to both the `build-release` and `publish-github-release` jobs to ensure the repository is checked out before executing the respective actions. [[1]](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7R69) [[2]](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7R81)