### PR TITLE
Specify shell in build and publish composite actions

### DIFF
--- a/.github/actions/build-release/action.yaml
+++ b/.github/actions/build-release/action.yaml
@@ -19,6 +19,7 @@ runs:
       uses: astral-sh/setup-uv@v5
 
     - name: Build distribution artifacts
+      shell: bash
       run: uv build
 
     - name: Store distribution artifacts

--- a/.github/actions/publish-github-release/action.yaml
+++ b/.github/actions/publish-github-release/action.yaml
@@ -27,6 +27,7 @@ runs:
         inputs: ./dist-${{ inputs.version }}/*.tar.gz ./dist-${{ inputs.version }}/*.whl
 
     - name: Create GitHub release
+      shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
@@ -42,6 +43,7 @@ runs:
           $prerelease_flag
  
     - name: Upload artifact signatures to GitHub release
+      shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: gh release upload ${{ inputs.version }} dist-${{ inputs.version }}/** --repo ${{ github.repository }}


### PR DESCRIPTION
This pull request includes small changes to the GitHub Actions workflow files to specify the shell to be used for running commands. The changes ensure that the commands are executed using the Bash shell.

Changes include:

* [`.github/actions/build-release/action.yaml`](diffhunk://#diff-46b7e3b123c06f12a6c6b506aac256da3872195c4c4bfca9f14df27fb1097b9bR22): Added `shell: bash` to the `Build distribution artifacts` step.
* [`.github/actions/publish-github-release/action.yaml`](diffhunk://#diff-7bd82437e2d4506c5bc54e330f4ca37f4245832d915b75e5acdf3c007d986d45R30): Added `shell: bash` to the `Create GitHub release` step.
* [`.github/actions/publish-github-release/action.yaml`](diffhunk://#diff-7bd82437e2d4506c5bc54e330f4ca37f4245832d915b75e5acdf3c007d986d45R46): Added `shell: bash` to the `Upload artifact signatures to GitHub release` step.