### PR TITLE
Updated publish-release name to publish-release-to-github

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -71,9 +71,9 @@ jobs:
         with:
           version: ${{ needs.tag-version.outputs.version }}
       
-  publish-release:
-    name: Publish release
-    needs: 
+  publish-release-to-github:
+    name: Publish release to GitHub
+    needs:
       - tag-version
       - build-release
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file, specifically renaming the job responsible for publishing releases.

* [`.github/workflows/publish-release.yaml`](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7L74-R75): Renamed the job `publish-release` to `publish-release-to-github` to clarify its purpose.