### PR TITLE
Actually, really, truly incorporated publish-pypi-release to publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -78,10 +78,26 @@ jobs:
       - build-release
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/publish-github-release
+        with:
+          version: ${{ needs.tag-version.outputs.version }}
+          target-branch: ${{ github.base_ref }}
+
+  publish-pypi-release:
+    name: Publish release to PyPI
+    needs:
+      - tag-version
+      - build-release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/publish-pypi-release
         with:
           version: ${{ needs.tag-version.outputs.version }}
           pypi-token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow to enhance the release process. The most important changes involve adding a new job to publish releases to PyPI and updating permissions for the existing release job.

Enhancements to release process:

* [`.github/workflows/publish-release.yaml`](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7R81-R100): Added a new job `publish-pypi-release` to publish releases to PyPI, including necessary steps and permissions.
* [`.github/workflows/publish-release.yaml`](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7R81-R100): Updated the `build-release` job to include write permissions for `contents` and added parameters for version and target branch.