### PR TITLE
Updated GitHub publish-release workflow

### DIFF
--- a/.github/actions/build-release/action.yaml
+++ b/.github/actions/build-release/action.yaml
@@ -1,12 +1,12 @@
 name: Build release
-description: Build the target version.
+description: Build distribution for the target version.
 inputs:
   version:
     required: true
     type: string
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -17,6 +17,8 @@ runs:
 
     - name: Install uv & prepare python
       uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: false
 
     - name: Build distribution artifacts
       shell: bash

--- a/.github/actions/publish-pypi-release/action.yaml
+++ b/.github/actions/publish-pypi-release/action.yaml
@@ -22,6 +22,7 @@ runs:
       # uses: pypa/gh-action-pypi-publish@release/v1
       # with:
       #   password: ${{ inputs.pypi-token }}
+      shell: bash
       run: |
         echo "Publishing to PyPI with version ${{ inputs.version }}"
         echo "Using token: ${{ inputs.pypi-token }}"


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow files to improve clarity and functionality. The most important changes include updating descriptions, modifying the build steps, and ensuring consistency across different action files.

Improvements to descriptions and inputs:

* [`.github/actions/build-release/action.yaml`](diffhunk://#diff-46b7e3b123c06f12a6c6b506aac256da3872195c4c4bfca9f14df27fb1097b9bL2-R9): Updated the description to "Build distribution for the target version."

Enhancements to build steps:

* [`.github/actions/build-release/action.yaml`](diffhunk://#diff-46b7e3b123c06f12a6c6b506aac256da3872195c4c4bfca9f14df27fb1097b9bR20-R21): Added `enable-cache: false` to the `setup-uv` step to ensure no caching is used.

Consistency improvements:

* [`.github/actions/publish-pypi-release/action.yaml`](diffhunk://#diff-0e4bb0e3539470e4eaf5188aeec927390bb22050d7d08573e8df691f0e22cb68R25): Added `shell: bash` to the publish step to ensure the script runs in the correct shell environment.