### PR TITLE
Removed erronous reference to "secrets" variable in publish-pypi-release action

### DIFF
--- a/.github/actions/publish-pypi-release/action.yaml
+++ b/.github/actions/publish-pypi-release/action.yaml
@@ -27,5 +27,3 @@ runs:
         echo "Publishing to PyPI with version ${{ inputs.version }}"
         echo "Using token: ${{ inputs.pypi-token }}"
         # Add your PyPI publishing logic here
-        # For example, you can use twine to upload the package
-        # twine upload dist-${{ inputs.version }}/* -u __token__ -p ${{ secrets.pypi-token }} --skip-existing


### PR DESCRIPTION
This pull request includes a small change to the `.github/actions/publish-pypi-release/action.yaml` file. The change removes commented-out code that provided an example of how to use `twine` to upload a package to PyPI. 

* [`.github/actions/publish-pypi-release/action.yaml`](diffhunk://#diff-0e4bb0e3539470e4eaf5188aeec927390bb22050d7d08573e8df691f0e22cb68L30-L31): Removed commented-out example code for using `twine` to upload the package.